### PR TITLE
add flag to change beam particle generator ID

### DIFF
--- a/SignalBackgroundMerger.cpp
+++ b/SignalBackgroundMerger.cpp
@@ -205,7 +205,7 @@ public:
     args.add_argument("-bg1St", "--bg1Status")
       .default_value(0)
       .scan<'i', int>()
-      .help("Apply shift on particle generatorStatus code for first background source. Default is 0. Recommand value: 1000 or larger. See appendix A in arxiv: 1912.08005");
+      .help("Apply shift on particle generatorStatus code for first background source. Default is 0. Recommended value: 1000 or larger. See appendix A in arxiv: 1912.08005");
 
     args.add_argument("-bg2", "--bg2File")
       .default_value(std::string("root://dtn-eic.jlab.org//work/eic2/EPIC/EVGEN/BACKGROUNDS/BEAMGAS/electron/beam_gas_ep_10GeV_foam_emin10keV_30Mevt.hepmc3.tree.root"))

--- a/SignalBackgroundMerger.cpp
+++ b/SignalBackgroundMerger.cpp
@@ -237,18 +237,13 @@ public:
       .help("Number of fourth background events to skip. Default is 0");
     
     args.add_argument("-o", "--outputFile")
-      .default_value(std::string("bgmerged"))
-      .help("Specify the output file name. By default bgmerged is used");
+      .default_value(std::string("bgmerged.hepmc3.tree.root"))
+      .help("Specify the output file name. By default bgmerged.hepmc3.tree.root is used");
 
     args.add_argument("-r", "--rootFormat")
       .default_value(true)
       .implicit_value(true)
       .help("Use hepmc.root output format, default is true.");
-
-    args.add_argument("-hepmc", "--hepmcFormat")
-      .default_value(false)
-      .implicit_value(true)
-      .help("Overwrite the --rootFormat flag to use .hepmc3 as output format, default is false.");
 	
     args.add_argument("-w", "--intWindow")
       .default_value(2000.0)
@@ -310,15 +305,7 @@ public:
     bg4Skip = args.get<int>("--bg4Skip");
     
     outputFile = args.get<std::string>("--outputFile");
-    rootFormat = !args.get<bool>("--hepmcFormat");
-    if (rootFormat){
-      if (!hasEnding(outputFile,".root"))
-        outputFile+=".hepmc3.tree.root";
-    }
-    else{
-      if (!hasEnding(outputFile,".hepmc3") || !hasEnding(outputFile,".hepmc"))
-      outputFile+=".hepmc3"; 
-    }
+    rootFormat = args.get<bool>("--rootFormat");
     intWindow  = args.get<double>("--intWindow");
     nSlices    = args.get<int>("--nSlices");
     squashTime = args.get<bool>("--squashTime");

--- a/SignalBackgroundMerger.cpp
+++ b/SignalBackgroundMerger.cpp
@@ -202,9 +202,9 @@ public:
     .help("Number of first background events to skip. Default is 0.");
 
     args.add_argument("-bg1St", "--bg1Status")
-      .default_value(2000)
+      .default_value(0)
       .scan<'i', int>()
-      .help("Base status code for first background source. Default is 2000");
+      .help("Base status code for first background source. Default is 0");
 
     args.add_argument("-bg2", "--bg2File")
       .default_value(std::string("root://dtn-eic.jlab.org//work/eic2/EPIC/EVGEN/BACKGROUNDS/BEAMGAS/electron/beam_gas_ep_10GeV_foam_emin10keV_30Mevt.hepmc3.tree.root"))
@@ -221,9 +221,9 @@ public:
       .help("Number of second background events to skip. Default is 0.");
 
     args.add_argument("-bg2St", "--bg2Status")
-      .default_value(4000)
+      .default_value(0)
       .scan<'i', int>()
-      .help("Base status code for second background source. Default is 4000");
+      .help("Base status code for second background source. Default is 0");
 
     args.add_argument("-bg3", "--bg3File")
       .default_value(std::string(""))
@@ -240,9 +240,9 @@ public:
       .help("Number of third background events to skip. Default is 0");
     
     args.add_argument("-bg3St", "--bg3Status")
-      .default_value(6000)
+      .default_value(0)
       .scan<'i', int>()
-      .help("Base status code for third background source. Default is 6000");
+      .help("Base status code for third background source. Default is 0");
 
     args.add_argument("-bg4", "--bg4File")
       .default_value(std::string("root://dtn-eic.jlab.org//work/eic2/EPIC/EVGEN/SIDIS/pythia6-eic/1.0.0/10x100/q2_0to1/pythia_ep_noradcor_10x100_q2_0.000000001_1.0_run2.ab.hepmc3.tree.root"))
@@ -259,9 +259,9 @@ public:
       .help("Number of fourth background events to skip. Default is 0");
 
     args.add_argument("-bg4St", "--bg4Status")
-      .default_value(8000)
+      .default_value(0)
       .scan<'i', int>()
-      .help("Base status code for fourth background source. Default is 8000");
+      .help("Base status code for fourth background source. Default is 0");
     
     args.add_argument("-o", "--outputFile")
       .default_value(std::string("bgmerged.hepmc3.tree.root"))

--- a/SignalBackgroundMerger.cpp
+++ b/SignalBackgroundMerger.cpp
@@ -354,25 +354,30 @@ public:
 
     std::cout << "Number of Slices:" << nSlices << endl;
     std::string freqTerm = signalFreq > 0 ? std::to_string(signalFreq) + " kHz" : "(one event per time slice)";
+    std::string statusTerm = signalStatus > 0 ? "Shifting all particle status codes from this source by" + std::to_string(signalStatus) : "";
     std::cout << "Signal events file and frequency:\n";
-    std::cout << "\t- " << signalFile << "\t" << freqTerm << "\n";
+    std::cout << "\t- " << signalFile << "\t" << freqTerm << "\n" << statusTerm << "\n";
     
     std::cout << "\nBackground files and their respective frequencies:\n";
     if (!bg1File.empty()) {
       freqTerm = bg1Freq > 0 ? std::to_string(bg1Freq) + " kHz" : "(from weights)";
-      std::cout << "\t- " << bg1File << "\t" << freqTerm << "\n";
+      statusTerm = bg1Status > 0 ? "Shifting all particle status codes from this source by" + std::to_string(bg1Status) : "";
+      std::cout << "\t- " << bg1File << "\t" << freqTerm << "\n" << statusTerm << "\n";
     }
     if (!bg2File.empty()) {
       freqTerm = bg2Freq > 0 ? std::to_string(bg2Freq) + " kHz" : "(from weights)";
-      std::cout << "\t- " << bg2File << "\t" << freqTerm << "\n";
+      statusTerm = bg2Status > 0 ? "Shifting all particle status codes from this source by" + std::to_string(bg2Status) : "";
+      std::cout << "\t- " << bg2File << "\t" << freqTerm << "\n" << statusTerm << "\n";
     }
     if (!bg3File.empty()) {
       freqTerm = bg3Freq > 0 ? std::to_string(bg3Freq) + " kHz" : "(from weights)";
-      std::cout << "\t- " << bg3File << "\t" << freqTerm << "\n";
+      statusTerm = bg3Status > 0 ? "Shifting all particle status codes from this source by" + std::to_string(bg3Status) : "";
+      std::cout << "\t- " << bg3File << "\t" << freqTerm << "\n" << statusTerm << "\n";
     }
     if (!bg4File.empty()) {
       freqTerm = bg4Freq > 0 ? std::to_string(bg4Freq) + " kHz" : "(from weights)";
-      std::cout << "\t- " << bg4File << "\t" << freqTerm << "\n";
+      statusTerm = bg4Status > 0 ? "Shifting all particle status codes from this source by" + std::to_string(bg4Status) : "";
+      std::cout << "\t- " << bg4File << "\t" << freqTerm << "\n" << statusTerm << "\n";
     }	
              
   }

--- a/SignalBackgroundMerger.cpp
+++ b/SignalBackgroundMerger.cpp
@@ -450,7 +450,7 @@ public:
     adapter->skip(skip);
     freqAdapters[fileName] = adapter;
     freqs[fileName] = freq;
-    baseStatuses[filename] = baseStatus;
+    baseStatuses[fileName] = baseStatus;
   }
 
    // ---------------------------------------------------------------------------
@@ -522,7 +522,7 @@ public:
     
     for (const auto& freqBgs : freqAdapters) {
       auto fileName=freqBgs.first;
-      addFreqEvents(fileName, freqAdapters[fileName], freqs[fileName], hepSlice, baseStatuses[filename], false);
+      addFreqEvents(fileName, freqAdapters[fileName], freqs[fileName], hepSlice, baseStatuses[fileName], false);
     }
     
     for (const auto& fileName : weightDict) {

--- a/SignalBackgroundMerger.cpp
+++ b/SignalBackgroundMerger.cpp
@@ -662,9 +662,7 @@ public:
       int status = particle->status();
       if (status == 1 ) finalParticleCount++;
       int pid = particle->pid();
-      if ((status == 1) || (status == 2)){
-          status += baseStatus;
-      }
+      status += baseStatus;
       auto p1 = std::make_shared<HepMC3::GenParticle> (momentum, pid, status);
       p1->set_generated_mass(particle->generated_mass());
       particles.push_back(p1);

--- a/SignalBackgroundMerger.cpp
+++ b/SignalBackgroundMerger.cpp
@@ -240,10 +240,15 @@ public:
       .default_value(std::string("bgmerged"))
       .help("Specify the output file name. By default bgmerged is used");
 
+    args.add_argument("-r", "--rootFormat")
+      .default_value(true)
+      .implicit_value(true)
+      .help("Use hepmc.root output format, default is true.");
+
     args.add_argument("-hepmc", "--hepmcFormat")
       .default_value(false)
       .implicit_value(true)
-      .help("Use .hepmc instead of hempmc.root as output format, default is false.");
+      .help("Overwrite the --rootFormat flag to use .hepmc3 as output format, default is false.");
 	
     args.add_argument("-w", "--intWindow")
       .default_value(2000.0)
@@ -306,10 +311,14 @@ public:
     
     outputFile = args.get<std::string>("--outputFile");
     rootFormat = !args.get<bool>("--hepmcFormat");
-    if (rootFormat)
-      outputFile+=".hepmc3.tree.root";
-    else
-      outputFile+=".hepmc3";
+    if (rootFormat){
+      if (!hasEnding(outputFile,".root"))
+        outputFile+=".hepmc3.tree.root";
+    }
+    else{
+      if (!hasEnding(outputFile,".hepmc3") || !hasEnding(outputFile,".hepmc"))
+      outputFile+=".hepmc3"; 
+    }
     intWindow  = args.get<double>("--intWindow");
     nSlices    = args.get<int>("--nSlices");
     squashTime = args.get<bool>("--squashTime");


### PR DESCRIPTION
### Briefly, what does this PR introduce?

Use flag --use_custom_bg_generator_id to set the primary particles (generator ID 1 and 2) from background particles to 201 and 202.

By default dd4hep will only proceed particles with generator ID =1, 2. The generated hepmc file works with dd4hep v1.32+ given the following options: 
`  --physics.alternativeStableStatuses=201 --physics.alternativeDecayStatuses=202
`
### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [x ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ x] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No
### Does this PR change default behavior?
No