### PR TITLE
feat: embed merger config into HepMC3 GenRunInfo

### DIFF
--- a/SignalBackgroundMerger.cpp
+++ b/SignalBackgroundMerger.cpp
@@ -170,7 +170,7 @@ public:
 
     runInfo->add_attribute("hepmc_merger_signal_file",
         std::make_shared<HepMC3::StringAttribute>(signalFile));
-    runInfo->add_attribute("signal_frequency_kHz",
+    runInfo->add_attribute("hepmc_merger_signal_frequency_kHz",
         std::make_shared<HepMC3::DoubleAttribute>(signalFreq));
 
     std::string bgFiles, bgFreqs, bgAvgRates;
@@ -186,16 +186,16 @@ public:
       }
       bgAvgRates += std::to_string(avgRate);
     }
-    runInfo->add_attribute("background_files",
+    runInfo->add_attribute("hepmc_merger_background_files",
         std::make_shared<HepMC3::StringAttribute>(bgFiles));
-    runInfo->add_attribute("background_frequencies_kHz",
+    runInfo->add_attribute("hepmc_merger_background_frequencies_kHz",
         std::make_shared<HepMC3::StringAttribute>(bgFreqs));
-    runInfo->add_attribute("background_avg_rates_kHz",
+    runInfo->add_attribute("hepmc_merger_background_avg_rates_kHz",
         std::make_shared<HepMC3::StringAttribute>(bgAvgRates));
 
-    runInfo->add_attribute("integration_window_ns",
+    runInfo->add_attribute("hepmc_merger_integration_window_ns",
         std::make_shared<HepMC3::DoubleAttribute>(intWindow));
-    runInfo->add_attribute("n_slices",
+    runInfo->add_attribute("hepmc_merger_n_slices",
         std::make_shared<HepMC3::IntAttribute>(nSlices));
 
     // Open output file — pass runInfo to constructor so it is written to the header

--- a/SignalBackgroundMerger.cpp
+++ b/SignalBackgroundMerger.cpp
@@ -168,7 +168,7 @@ public:
     // Populate run-level metadata
     auto runInfo = std::make_shared<HepMC3::GenRunInfo>();
 
-    runInfo->add_attribute("signal_file",
+    runInfo->add_attribute("hepmc_merger_signal_file",
         std::make_shared<HepMC3::StringAttribute>(signalFile));
     runInfo->add_attribute("signal_frequency_kHz",
         std::make_shared<HepMC3::DoubleAttribute>(signalFreq));

--- a/SignalBackgroundMerger.cpp
+++ b/SignalBackgroundMerger.cpp
@@ -165,13 +165,46 @@ public:
   void merge(){
     auto t1 = std::chrono::high_resolution_clock::now();
 
-    // Open output file
+    // Populate run-level metadata
+    auto runInfo = std::make_shared<HepMC3::GenRunInfo>();
+
+    runInfo->add_attribute("signal_file",
+        std::make_shared<HepMC3::StringAttribute>(signalFile));
+    runInfo->add_attribute("signal_frequency_kHz",
+        std::make_shared<HepMC3::DoubleAttribute>(signalFreq));
+
+    std::string bgFiles, bgFreqs, bgAvgRates;
+    for (size_t bi = 0; bi < backgroundFiles.size(); ++bi) {
+      if (bi) { bgFiles += ";"; bgFreqs += ";"; bgAvgRates += ";"; }
+      bgFiles += backgroundFiles[bi].file;
+      bgFreqs += std::to_string(backgroundFiles[bi].frequency);
+      double avgRate = 0.0;
+      if (backgroundFiles[bi].frequency <= 0.0) {
+        auto it = weightDict.find(backgroundFiles[bi].file);
+        if (it != weightDict.end())
+          avgRate = std::get<2>(it->second) * 1e6; // GHz -> kHz
+      }
+      bgAvgRates += std::to_string(avgRate);
+    }
+    runInfo->add_attribute("background_files",
+        std::make_shared<HepMC3::StringAttribute>(bgFiles));
+    runInfo->add_attribute("background_frequencies_kHz",
+        std::make_shared<HepMC3::StringAttribute>(bgFreqs));
+    runInfo->add_attribute("background_avg_rates_kHz",
+        std::make_shared<HepMC3::StringAttribute>(bgAvgRates));
+
+    runInfo->add_attribute("integration_window_ns",
+        std::make_shared<HepMC3::DoubleAttribute>(intWindow));
+    runInfo->add_attribute("n_slices",
+        std::make_shared<HepMC3::IntAttribute>(nSlices));
+
+    // Open output file — pass runInfo to constructor so it is written to the header
     std::shared_ptr<HepMC3::Writer> f;
     if (rootFormat)
-      f = std::make_shared<HepMC3::WriterRootTree>(outputFileName);
+      f = std::make_shared<HepMC3::WriterRootTree>(outputFileName, runInfo);
     else
-      f = std::make_shared<HepMC3::WriterAscii>(outputFileName);
-    
+      f = std::make_shared<HepMC3::WriterAscii>(outputFileName, runInfo);
+
     // Slice loop
     int i = 0;
     for (i = 0; i<nSlices; ++i ) {


### PR DESCRIPTION
### Briefly, what does this PR introduce?
Populate GenRunInfo attributes before writer construction so they are serialized into the file header and propagate through DD4hep/npsim into the EDM4hep runs frame. Stored fields: signal_file, signal_frequency_kHz, background_files, background_frequencies_kHz, background_avg_rates_kHz (for weighted sources), integration_window_ns, n_slices.

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?

### Does this PR change default behavior?
