### PR TITLE
fix: include unistd.h for `_SC_PAGESIZE`

### DIFF
--- a/SignalBackgroundMerger.cpp
+++ b/SignalBackgroundMerger.cpp
@@ -16,6 +16,7 @@
 #include <cmath>
 #include <random>
 #include <tuple>
+#include <unistd.h>
 #include <sys/resource.h>
 
 #include <HepMC3/ReaderFactory.h>


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This PR fixes a compilation issue due to the user of `_SC_PAGESIZE`, but the lack of inclusion of the `unistd.h` header. Since macOS is POSIX, I assume this doesn't need to be gated.