### PR TITLE
 fix: change wrap around to not start at the beginning, but start at a modulo of the value

### DIFF
--- a/SignalBackgroundMerger.cpp
+++ b/SignalBackgroundMerger.cpp
@@ -20,6 +20,7 @@
 #include <sys/resource.h>
 
 #include <HepMC3/ReaderFactory.h>
+#include <HepMC3/ReaderRootTree.h>
 #include <HepMC3/WriterAscii.h>
 #include "HepMC3/WriterRootTree.h"
 #include "HepMC3/GenRunInfo.h"
@@ -421,7 +422,7 @@ public:
     cout << "Prepping " << fileName << endl;
     std::shared_ptr<HepMC3::Reader> adapter;
     try {
-      adapter = HepMC3::deduce_reader(fileName);
+      adapter = openReader(fileName);
       if (!adapter) {
         throw std::runtime_error("Failed to open file");
       }
@@ -436,7 +437,7 @@ public:
       sigAdapter = adapter;
       sigFreq = freq;
       sigStatus = baseStatus;
-      sigAdapter->skip(skip);
+      applySmartSkip(fileName, sigAdapter, skip);
       return;
     }
 
@@ -484,10 +485,52 @@ public:
     }
 
     // Not signal and not weighted --> prepare frequency backgrounds
-    adapter->skip(skip);
+    applySmartSkip(fileName, adapter, skip);
     freqAdapters[fileName] = adapter;
     freqs[fileName] = freq;
     baseStatuses[fileName] = baseStatus;
+  }
+
+  // ---------------------------------------------------------------------------
+  /// Open a HepMC3 file. For .root inputs construct ReaderRootTree directly so
+  /// we can reach its TTree; deduce_reader wraps it in a ReaderPlugin whose
+  /// underlying Reader* is private and thus not dynamic_cast'able.
+  std::shared_ptr<HepMC3::Reader> openReader(const std::string& fileName) {
+    auto endsWith = [](const std::string& s, const std::string& suffix) {
+      return s.size() >= suffix.size() &&
+             s.compare(s.size() - suffix.size(), suffix.size(), suffix) == 0;
+    };
+    if (endsWith(fileName, ".root")) {
+      return std::make_shared<HepMC3::ReaderRootTree>(fileName);
+    }
+    return HepMC3::deduce_reader(fileName);
+  }
+
+  // ---------------------------------------------------------------------------
+  /// Apply skip, wrapping modulo the file's event count for ROOT TTree inputs.
+  void applySmartSkip(const std::string& fileName,
+                      std::shared_ptr<HepMC3::Reader>& adapter,
+                      long long skip) {
+    if (skip <= 0) { adapter->skip(0); return; }
+    if (auto rrt = std::dynamic_pointer_cast<HepMC3::ReaderRootTree>(adapter)) {
+      Long64_t N = rrt->m_tree ? rrt->m_tree->GetEntries() : 0;
+      if (N > 0) {
+        long long wrapped = skip % static_cast<long long>(N);
+        if (wrapped != skip) {
+          std::cout << "Wrapping skip " << skip << " -> " << wrapped
+                    << " (mod " << N << " events) for " << fileName << std::endl;
+        }
+        adapter->skip(static_cast<int>(wrapped));
+        return;
+      }
+    }
+    if (skip > std::numeric_limits<int>::max()) {
+      std::cout << "Warning: skip " << skip << " exceeds INT_MAX for " << fileName
+                << "; using skip=0 (non-ROOT reader, no length known)." << std::endl;
+      adapter->skip(0);
+    } else {
+      adapter->skip(static_cast<int>(skip));
+    }
   }
 
    // ---------------------------------------------------------------------------
@@ -598,18 +641,20 @@ public:
 
     // Insert events at all specified locations
     for (double time : timeline) {
-      if(adapter->failed()) {
-      try{
-        if (signal) { // Exhausted signal events
-	        throw std::ifstream::failure("EOF");
-	      } else { // background file reached its end, reset to the start
-	        std::cout << "Cycling back to the start of " << fileName << std::endl;
-	        adapter->close();
-	        adapter = HepMC3::deduce_reader(fileName);
-	      }
-	    } catch (std::ifstream::failure& e) {
-	        continue; // just need to suppress the error
+      if (adapter->failed()) {
+        if (signal) {
+          // Exhausted signal events; stop trying to place more.
+          break;
         }
+        // background file reached its end, reset to the start and retry this slot
+        std::cout << "Cycling back to the start of " << fileName << std::endl;
+        adapter->close();
+        adapter = openReader(fileName);
+        if (!adapter || adapter->failed()) {
+          std::cerr << "Failed to reopen " << fileName << " after cycling." << std::endl;
+          break;
+        }
+        // fall through and read event 0 for this timeline entry
       }
 
       HepMC3::GenEvent inevt;

--- a/SignalBackgroundMerger.cpp
+++ b/SignalBackgroundMerger.cpp
@@ -524,13 +524,7 @@ public:
         return;
       }
     }
-    if (skip > std::numeric_limits<int>::max()) {
-      std::cout << "Warning: skip " << skip << " exceeds INT_MAX for " << fileName
-                << "; using skip=0 (non-ROOT reader, no length known)." << std::endl;
-      adapter->skip(0);
-    } else {
-      adapter->skip(static_cast<int>(skip));
-    }
+    adapter->skip(static_cast<int>(skip));
   }
 
    // ---------------------------------------------------------------------------

--- a/SignalBackgroundMerger.cpp
+++ b/SignalBackgroundMerger.cpp
@@ -55,7 +55,7 @@ const char* hepmc_merger_version = _AS_STRING(HEPMC_MERGER_VERSION_FULL);
 struct BackgroundConfig {
     std::string file;
     double frequency=0;
-    int skip=0;
+    long long skip=0;
     int status=0;
 } ;
 
@@ -153,7 +153,7 @@ public:
         BackgroundConfig bg;
         bg.file = raw_args_list[i];
         bg.frequency = std::stod(raw_args_list[i + 1]);
-        bg.skip = (args_count > 2) ? std::stoi(raw_args_list[i + 2]) : 0;
+        bg.skip = (args_count > 2) ? std::stoll(raw_args_list[i + 2]) : 0;
         bg.status = (args_count > 3) ? std::stoi(raw_args_list[i + 3]) : 0;
         backgrounds.push_back(bg);
       } catch (const std::exception &e) {


### PR DESCRIPTION
### Briefly, what does this PR introduce? Please link to any relevant presentations or discussions.

This fixes an ongoing issue where recent change to the campaign background mixing skips https://github.com/eic/simulation_campaign_hepmc3/pull/95 produced values exceeding event counts. The reliance on wrap around was bogus, because the current behaviour of wrapping to 0 defeats the goal. There are other ways to address this.

### What is the urgency of this PR?
- [x] High (please describe reason below)
  might be useful to fix ASAP
- [ ] Medium
- [ ] Low

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Optimization (issue #__)
- [ ] Updated documentation
- [ ] other: __

### Please check if any of the following apply
- [ ] This PR introduces breaking changes. Please describe changes users need to make below.
- [ ] This PR changes default behavior. Please describe changes below.
- [x] AI was used in preparing this PR. Please describe usage below.
  claude